### PR TITLE
Fix user GET endpoint to retrieve reminders

### DIFF
--- a/api/src/api/routes/user.ts
+++ b/api/src/api/routes/user.ts
@@ -1,5 +1,6 @@
 import User from '../../models/user.model';
 import { type RequestHandler, Router } from 'express';
+import Reminder from '../../models/reminder.model';
 import reminderRouter from './reminder';
 import '../../lib/passport';
 import Crypto from 'crypto';
@@ -39,8 +40,9 @@ userRouter.get('/', (async (req, res, next) => {
 }) as RequestHandler);
 
 userRouter.get('/:idUser', (async (req, res, next) => {
-  User.findOne({ where: { id: req.params.idUser } })
-    .then((user) => {
+  const body = req.body;
+  User.findOne({ where: { id: req.params.idUser }, include: [Reminder] })
+    .then(user => {
       if (!user) {
         return res
           .status(401)

--- a/api/src/models/reminder.model.ts
+++ b/api/src/models/reminder.model.ts
@@ -8,7 +8,6 @@ import {
   PrimaryKey,
   Table,
   UpdatedAt,
-  ForeignKey,
 } from 'sequelize-typescript';
 import User from './user.model';
 import Lesion from './lesion.model';
@@ -20,13 +19,17 @@ export default class Reminder extends Model {
   @Column
     id!: number;
 
-  @ForeignKey(() => User)
   @Column
     idUser!: number;
 
-  @ForeignKey(() => Lesion)
+  @BelongsTo(() => User, {foreignKey: 'idUser', targetKey: 'id'})
+    user!: User;
+
   @Column
     idLesion!: number;
+
+  @BelongsTo(() => Lesion, {foreignKey: 'idLesion', targetKey: 'id'})
+    lesion!: Lesion;
 
   @CreatedAt
     creationDate?: Date;
@@ -40,6 +43,4 @@ export default class Reminder extends Model {
   @Column
     targetTimeStamp?: Date;
 
-  @BelongsTo(() => User)
-    user!: User;
 }

--- a/api/src/models/user.model.ts
+++ b/api/src/models/user.model.ts
@@ -44,7 +44,7 @@ export default class User extends Model {
   @DeletedAt
     deletionDate?: Date;
 
-  @HasMany(() => Reminder)
+  @HasMany(() => Reminder, { foreignKey: 'idUser', sourceKey: 'id'})
     reminders?: Reminder[];
 
   @HasMany(() => Lesion)


### PR DESCRIPTION
Before this, if `/user/:idUser` endpoint was called, the reminders associated with a user weren't retrieved, which is an unexpected behavior. This fixes the endpoint to retrieve the reminders of a user.