### PR TITLE
Fix patient relationship primary key

### DIFF
--- a/api/src/api/routes/user.ts
+++ b/api/src/api/routes/user.ts
@@ -172,7 +172,7 @@ userRouter.post('/:idUser/associate/:idPatient', (async (req, res, next) => {
   try {
     await patientRelationship.save();
   } catch (error) {
-    log.error(error);
+    log.error('Error while saving the relationship: ', error);
     return res.status(500).send({
       result: false,
       message: 'Internal Error',

--- a/api/src/models/patientRelationship.model.ts
+++ b/api/src/models/patientRelationship.model.ts
@@ -3,17 +3,19 @@ import {
   Table,
   ForeignKey,
   Column,
-  // BelongsTo,
+  PrimaryKey,
 } from 'sequelize-typescript';
 import User from './user.model';
 
 @Table
 export default class PatientRelationship extends Model {
   @ForeignKey(() => User)
+  @PrimaryKey
   @Column
     doctorId!: number;
 
   @ForeignKey(() => User)
+  @PrimaryKey
   @Column
     patientId!: number;
 }


### PR DESCRIPTION
This fixes the patient relationship model making both id's its primary key, as before there couldn't be more than one relationship with the same doctorId which isn't the expected behavior.