### PR TITLE
Fix dispatcher to read base64 images

### DIFF
--- a/backend/dispatcher.py
+++ b/backend/dispatcher.py
@@ -38,7 +38,7 @@ def extract(blobName):
     img = download_image(blobName)
     verify_image_content(img, blobName)
 
-    result = img_proc.extract(img['data'])
+    result = img_proc.extract(img)
 
     return json.dumps(result)
 

--- a/backend/image_processing/processor.py
+++ b/backend/image_processing/processor.py
@@ -13,7 +13,7 @@ def process_image(img):
 
 
 def extract(img):
-    img_cv2 = converter.tocv2Img(img)
+    img_cv2 = converter.convertToOpenCVFormat(img)
     [processed_img, msk] = process_image(img_cv2)
 
     return {

--- a/backend/image_processing/util/converter.py
+++ b/backend/image_processing/util/converter.py
@@ -1,6 +1,9 @@
 import cv2
+import base64
 import numpy as np
 
-def tocv2Img(image):
-    nparr = np.fromstring(image, np.uint8)
+def convertToOpenCVFormat(image):
+    base64_string = image['data'].split(b",")[1]
+    image_data = base64.b64decode(base64_string)
+    nparr = np.frombuffer(image_data, np.uint8)
     return cv2.imdecode(nparr, cv2.IMREAD_COLOR)


### PR DESCRIPTION
This fixes the dispatcher to process base64 formated images from the storage.
Fixes 

> Make dispatcher reads images in base64

in #39.