### PR TITLE
Add cycleLength property to reminders

### DIFF
--- a/api.yml
+++ b/api.yml
@@ -12,6 +12,7 @@ paths:
   # /user/{idUser}/reminder/{lesionId}: # add reminder to user
   # /user/{idUser}/associate/{idPatient}: # associate two users
   # /user/{idUser}/share/{idUserToAssociate}/{lesionId}: # share user's lesion to another user
+  # /user/{idUser/reminder/discard/{reminderId}: # discard reminder and update it if necessary
   # /operation/analyze/{operation}: # compare two photos
   # /prediagnose: # prediagnose a photo
 
@@ -264,6 +265,28 @@ paths:
         '401':
           $ref: "#/components/responses/Unauthorized"
 
+  /user/{idUser}/reminder/discard/{idReminder}:
+    parameters:
+      - $ref: '#/components/parameters/idUser'
+      - $ref: '#/components/parameters/idReminder'
+    post:
+      description: Discards a reminder and creates a new one based on the cycleLength
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/discard'
+      responses:
+        '200':
+          $ref: "#/components/responses/OK"
+        '404':
+          $ref: "#/components/responses/NotFound"
+        '401':
+          $ref: "#/components/responses/Unauthorized"
+        '400':
+          $ref: "#/components/responses/BadRequest"
+
   /user/{idUser}/associate/{idPatient}:
     parameters:
       - $ref: '#/components/parameters/idUser'
@@ -445,6 +468,8 @@ components:
           type: string
         lesionID:
           type: number
+        cycleLength:
+          type: number
     analyze:
       type: object
       properties:
@@ -459,4 +484,9 @@ components:
           type: string
         password:
           type: string
+    discard:
+      type: object
+      properties:
+        erase:
+          type: bool
 

--- a/api.yml
+++ b/api.yml
@@ -12,7 +12,7 @@ paths:
   # /user/{idUser}/reminder/{lesionId}: # add reminder to user
   # /user/{idUser}/associate/{idPatient}: # associate two users
   # /user/{idUser}/share/{idUserToAssociate}/{lesionId}: # share user's lesion to another user
-  # /user/{idUser/reminder/discard/{reminderId}: # discard reminder and update it if necessary
+  # /user/{idUser/reminder/{reminderId}/discard: # discard reminder and update it if necessary
   # /operation/analyze/{operation}: # compare two photos
   # /prediagnose: # prediagnose a photo
 
@@ -265,7 +265,7 @@ paths:
         '401':
           $ref: "#/components/responses/Unauthorized"
 
-  /user/{idUser}/reminder/discard/{idReminder}:
+  /user/{idUser}/reminder/{idReminder}/discard/:
     parameters:
       - $ref: '#/components/parameters/idUser'
       - $ref: '#/components/parameters/idReminder'

--- a/api/src/api/routes/reminder.ts
+++ b/api/src/api/routes/reminder.ts
@@ -35,6 +35,9 @@ reminderRouter.post('/:idLesion', (async (req, res, next) => {
       message: 'missing target date',
     });
   }
+  if (reminder.cycleLength == null) {
+          reminder.cycleLength = 0;
+  }
   const options = {
     body: reminder as Reminder,
     params: {

--- a/api/src/api/routes/reminder.ts
+++ b/api/src/api/routes/reminder.ts
@@ -142,7 +142,7 @@ reminderRouter.delete('/:idReminder', (async (req, res, next) => {
   }
 }) as RequestHandler);
 
-reminderRouter.post('/discard/:idReminder', (async (req, res, next) => {
+reminderRouter.post('/:idReminder/discard', (async (req, res, next) => {
   if (req.params.idReminder == null) {
     return res.status(400).send({
       result: false,

--- a/api/src/api/routes/reminder.ts
+++ b/api/src/api/routes/reminder.ts
@@ -5,7 +5,9 @@ import {
   getReminderById,
   patchReminderById,
   postReminder,
+  discardReminder,
 } from '../services/reminder';
+import log from '../../lib/logger'
 
 const reminderRouter = Router({ mergeParams: true });
 
@@ -137,4 +139,37 @@ reminderRouter.delete('/:idReminder', (async (req, res, next) => {
   }
 }) as RequestHandler);
 
+reminderRouter.post('/discard/:idReminder', (async (req, res, next) => {
+  if (req.params.idReminder == null) {
+    return res.status(400).send({
+      result: false,
+      message: 'missing reminder id',
+    });
+  }
+  if (req.params.idUser == null) {
+    return res.status(400).send({
+      result: false,
+      message: 'missing user id',
+    });
+  }
+  let erase = false;
+  if (req.body.erase != null) {
+    erase = Boolean(req.body.erase);
+  }
+  const options = {
+    params: {
+      idUser: Number(req.params.idUser),
+      idReminder: Number(req.params.idReminder),
+      erase: erase,
+    },
+    body: null,
+  };
+
+  try {
+    const result = await discardReminder(options);
+    res.status(result.status).send(result.data);
+  } catch (err) {
+    next(err);
+  }
+}) as RequestHandler);
 export default reminderRouter;

--- a/api/src/api/services/reminder.ts
+++ b/api/src/api/services/reminder.ts
@@ -10,6 +10,7 @@ export const postReminder = async (
       idLesion: options.params.idLesion,
       idUser: options.params.idUser,
       targetTimeStamp: options.body.targetTimeStamp,
+      cycleLength: options.body.cycleLength,
     });
     await reminder.save();
     return {
@@ -132,6 +133,56 @@ export const deleteReminderById = async (
       data: {
         result: false,
         message: 'Error deleting reminder',
+      },
+    };
+  }
+};
+
+export const discardReminder = async (
+  options: RequestOptions<
+  unknown,
+  { idUser: number; idReminder: number; erase: boolean }
+  >,
+) => {
+  try {
+    const reminder = await Reminder.findByPk(options.params.idReminder);
+    if (reminder === null) {
+      return {
+        status: 404,
+        data: {
+          result: false,
+          message: 'Reminder does not exists',
+        },
+      };
+    }
+    options.params.erase =
+      reminder.cycleLength === 0 ||
+      reminder.targetTimeStamp === undefined ||
+      options.params.erase;
+    log.info('Reminder was returned');
+    if (options.params.erase) {
+      return await deleteReminderById(options);
+    }
+    const current = reminder.targetTimeStamp ?? new Date();
+    const future = new Date(
+      current.getTime() + reminder.cycleLength * 60 * 60 * 1000,
+    );
+    reminder.targetTimeStamp = future;
+    const patchOptions = {
+      params: {
+        idUser: options.params.idUser,
+        idReminder: options.params.idReminder,
+      },
+      body: reminder,
+    };
+    return await patchReminderById(patchOptions);
+  } catch (error) {
+    log.error(error, 'Error discarding reminder');
+    return {
+      status: 400,
+      data: {
+        result: false,
+        message: 'Error getting photo',
       },
     };
   }

--- a/api/src/api/services/reminder.ts
+++ b/api/src/api/services/reminder.ts
@@ -52,12 +52,12 @@ export const getReminderById = async (
       data: reminder,
     };
   } catch (error) {
-    log.error(error, 'Error getting photo');
+    log.error(error, 'Error getting reminder');
     return {
       status: 400,
       data: {
         result: false,
-        message: 'Error getting photo',
+        message: 'Error getting reminder',
       },
     };
   }
@@ -182,7 +182,7 @@ export const discardReminder = async (
       status: 400,
       data: {
         result: false,
-        message: 'Error getting photo',
+        message: 'Error getting reminder',
       },
     };
   }

--- a/api/src/models/reminder.model.ts
+++ b/api/src/models/reminder.model.ts
@@ -22,6 +22,10 @@ export default class Reminder extends Model {
   @Column
     idUser!: number;
 
+  // In hours
+  @Column
+    cycleLength!: number;
+
   @BelongsTo(() => User, { foreignKey: 'idUser', targetKey: 'id' })
     user!: User;
 


### PR DESCRIPTION

This creates a new property in the reminders model named cycleLength
which represents the time in hours that each reminder should be set to
every time that it's discarded. This also adds the discard endpoint
which deletes completely the reminder or creates a new one according to
the cycleLength property.

Fixes
> Add cycle length property to reminders
Auto renew reminders when deleting

in #35.